### PR TITLE
Sets the length of the navigation bar and the loading bar.

### DIFF
--- a/css/rpg-ui.css
+++ b/css/rpg-ui.css
@@ -632,7 +632,8 @@ button#roll-hd:hover::before {
 
 /* NAVIGATION */
 
-#navigation {
+#ui-top {
+    width: calc(100% - 340px);
     left: 142px;
 }
 


### PR DESCRIPTION
Sets the length of the navigation bar and the loading bar.

Before 
<img src="https://puu.sh/IFKDS/3fb22cdac4.png">

after
<img src="https://puu.sh/IFKBZ/162a1d44cd.png">